### PR TITLE
Example pull request causing a bad rename

### DIFF
--- a/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpRequestTest.java
+++ b/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpRequestTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.http.ByteArrayContent;
-import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpContentFoo;
 import com.google.api.client.http.InputStreamContent;
 import com.google.api.client.testing.http.apache.MockHttpClient;
 import java.io.ByteArrayInputStream;
@@ -33,7 +33,7 @@ public class ApacheHttpRequestTest {
   public void testContentLengthSet() throws Exception {
     HttpExtensionMethod base = new HttpExtensionMethod("POST", "http://www.google.com");
     ApacheHttpRequest request = new ApacheHttpRequest(new MockHttpClient(), base);
-    HttpContent content =
+    HttpContentFoo content =
         new ByteArrayContent("text/plain", "sample".getBytes(StandardCharsets.UTF_8));
     request.setStreamingContent(content);
     request.setContentLength(content.getLength());
@@ -49,7 +49,7 @@ public class ApacheHttpRequestTest {
     Arrays.fill(buf, (byte) ' ');
     HttpExtensionMethod base = new HttpExtensionMethod("POST", "http://www.google.com");
     ApacheHttpRequest request = new ApacheHttpRequest(new MockHttpClient(), base);
-    HttpContent content = new InputStreamContent("text/plain", new ByteArrayInputStream(buf));
+    HttpContentFoo content = new InputStreamContent("text/plain", new ByteArrayInputStream(buf));
     request.setStreamingContent(content);
     request.execute();
 

--- a/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java
@@ -28,7 +28,7 @@ import java.nio.charset.Charset;
  * @since 1.5
  * @author Yaniv Inbar
  */
-public abstract class AbstractHttpContent implements HttpContent {
+public abstract class AbstractHttpContent implements HttpContentFoo {
 
   /** Media type used for the Content-Type header or {@code null} for none. */
   private HttpMediaType mediaType;
@@ -105,7 +105,7 @@ public abstract class AbstractHttpContent implements HttpContent {
    * Computes and returns the content length or less than zero if not known.
    *
    * <p>Subclasses may override, but by default this computes the length by calling {@link
-   * #computeLength(HttpContent)}.
+   * #computeLength(HttpContentFoo)}.
    */
   protected long computeLength() throws IOException {
     return computeLength(this);
@@ -118,14 +118,14 @@ public abstract class AbstractHttpContent implements HttpContent {
 
   /**
    * Returns the computed content length based using {@link IOUtils#computeLength(StreamingContent)}
-   * or instead {@code -1} if {@link HttpContent#retrySupported()} is {@code false} because the
+   * or instead {@code -1} if {@link HttpContentFoo#retrySupported()} is {@code false} because the
    * stream must not be read twice.
    *
    * @param content HTTP content
    * @return computed content length or {@code -1} if retry is not supported
    * @since 1.14
    */
-  public static long computeLength(HttpContent content) throws IOException {
+  public static long computeLength(HttpContentFoo content) throws IOException {
     if (!content.retrySupported()) {
       return -1;
     }

--- a/google-http-client/src/main/java/com/google/api/client/http/AbstractInputStreamContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/AbstractInputStreamContent.java
@@ -34,7 +34,7 @@ import java.io.OutputStream;
  * @since 1.4
  * @author moshenko@google.com (Jacob Moshenko)
  */
-public abstract class AbstractInputStreamContent implements HttpContent {
+public abstract class AbstractInputStreamContent implements HttpContentFoo {
 
   /** Content type or {@code null} for none. */
   private String type;

--- a/google-http-client/src/main/java/com/google/api/client/http/EmptyContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/EmptyContent.java
@@ -29,7 +29,7 @@ import java.io.OutputStream;
  * @since 1.11
  * @author Yaniv Inbar
  */
-public class EmptyContent implements HttpContent {
+public class EmptyContent implements HttpContentFoo {
 
   public long getLength() throws IOException {
     return 0;

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpContentFoo.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpContentFoo.java
@@ -26,7 +26,7 @@ import java.io.OutputStream;
  * @since 1.0
  * @author Yaniv Inbar
  */
-public interface HttpContent extends StreamingContent {
+public interface HttpContentFoo extends StreamingContent {
 
   /** Returns the content length or less than zero if not known. */
   long getLength() throws IOException;

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -130,7 +130,7 @@ public final class HttpRequest {
   private boolean curlLoggingEnabled = true;
 
   /** HTTP request content or {@code null} for none. */
-  private HttpContent content;
+  private HttpContentFoo content;
 
   /** HTTP transport. */
   private final HttpTransport transport;
@@ -272,7 +272,7 @@ public final class HttpRequest {
    *
    * @since 1.5
    */
-  public HttpContent getContent() {
+  public HttpContentFoo getContent() {
     return content;
   }
 
@@ -281,7 +281,7 @@ public final class HttpRequest {
    *
    * @since 1.5
    */
-  public HttpRequest setContent(HttpContent content) {
+  public HttpRequest setContent(HttpContentFoo content) {
     this.content = content;
     return this;
   }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequestFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequestFactory.java
@@ -81,7 +81,7 @@ public final class HttpRequestFactory {
    * @return new HTTP request
    * @since 1.12
    */
-  public HttpRequest buildRequest(String requestMethod, GenericUrl url, HttpContent content)
+  public HttpRequest buildRequest(String requestMethod, GenericUrl url, HttpContentFoo content)
       throws IOException {
     HttpRequest request = transport.buildRequest();
     if (initializer != null) {
@@ -124,7 +124,7 @@ public final class HttpRequestFactory {
    * @param content HTTP request content or {@code null} for none
    * @return new HTTP request
    */
-  public HttpRequest buildPostRequest(GenericUrl url, HttpContent content) throws IOException {
+  public HttpRequest buildPostRequest(GenericUrl url, HttpContentFoo content) throws IOException {
     return buildRequest(HttpMethods.POST, url, content);
   }
 
@@ -135,7 +135,7 @@ public final class HttpRequestFactory {
    * @param content HTTP request content or {@code null} for none
    * @return new HTTP request
    */
-  public HttpRequest buildPutRequest(GenericUrl url, HttpContent content) throws IOException {
+  public HttpRequest buildPutRequest(GenericUrl url, HttpContentFoo content) throws IOException {
     return buildRequest(HttpMethods.PUT, url, content);
   }
 
@@ -146,7 +146,7 @@ public final class HttpRequestFactory {
    * @param content HTTP request content or {@code null} for none
    * @return new HTTP request
    */
-  public HttpRequest buildPatchRequest(GenericUrl url, HttpContent content) throws IOException {
+  public HttpRequest buildPatchRequest(GenericUrl url, HttpContentFoo content) throws IOException {
     return buildRequest(HttpMethods.PATCH, url, content);
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/http/MultipartContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/MultipartContent.java
@@ -73,7 +73,7 @@ public class MultipartContent extends AbstractHttpContent {
           .setContentLength(null)
           .set("Content-Transfer-Encoding", null);
       // analyze the content
-      HttpContent content = part.content;
+      HttpContentFoo content = part.content;
       StreamingContent streamingContent = null;
       if (content != null) {
         headers.set("Content-Transfer-Encoding", Arrays.asList("binary"));
@@ -168,9 +168,9 @@ public class MultipartContent extends AbstractHttpContent {
    * <p>Overriding is only supported for the purpose of calling the super implementation and
    * changing the return type, but nothing else.
    */
-  public MultipartContent setContentParts(Collection<? extends HttpContent> contentParts) {
+  public MultipartContent setContentParts(Collection<? extends HttpContentFoo> contentParts) {
     this.parts = new ArrayList<>(contentParts.size());
-    for (HttpContent contentPart : contentParts) {
+    for (HttpContentFoo contentPart : contentParts) {
       addPart(new Part(contentPart));
     }
     return this;
@@ -202,7 +202,7 @@ public class MultipartContent extends AbstractHttpContent {
   public static final class Part {
 
     /** HTTP content or {@code null} for none. */
-    HttpContent content;
+    HttpContentFoo content;
 
     /** HTTP headers or {@code null} for none. */
     HttpHeaders headers;
@@ -215,7 +215,7 @@ public class MultipartContent extends AbstractHttpContent {
     }
 
     /** @param content HTTP content or {@code null} for none */
-    public Part(HttpContent content) {
+    public Part(HttpContentFoo content) {
       this(null, content);
     }
 
@@ -223,19 +223,19 @@ public class MultipartContent extends AbstractHttpContent {
      * @param headers HTTP headers or {@code null} for none
      * @param content HTTP content or {@code null} for none
      */
-    public Part(HttpHeaders headers, HttpContent content) {
+    public Part(HttpHeaders headers, HttpContentFoo content) {
       setHeaders(headers);
       setContent(content);
     }
 
     /** Sets the HTTP content or {@code null} for none. */
-    public Part setContent(HttpContent content) {
+    public Part setContent(HttpContentFoo content) {
       this.content = content;
       return this;
     }
 
     /** Returns the HTTP content or {@code null} for none. */
-    public HttpContent getContent() {
+    public HttpContentFoo getContent() {
       return content;
     }
 

--- a/google-http-client/src/main/java/com/google/api/client/http/UrlEncodedContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/UrlEncodedContent.java
@@ -139,7 +139,7 @@ public class UrlEncodedContent extends AbstractHttpContent {
    * @since 1.7
    */
   public static UrlEncodedContent getContent(HttpRequest request) {
-    HttpContent content = request.getContent();
+    HttpContentFoo content = request.getContent();
     if (content != null) {
       return (UrlEncodedContent) content;
     }

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/MockHttpContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/MockHttpContent.java
@@ -14,7 +14,7 @@
 
 package com.google.api.client.testing.http;
 
-import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpContentFoo;
 import com.google.api.client.util.Beta;
 import com.google.api.client.util.Preconditions;
 import java.io.IOException;
@@ -22,7 +22,7 @@ import java.io.OutputStream;
 
 /**
  * {@link Beta} <br>
- * Mock for {@link HttpContent}.
+ * Mock for {@link HttpContentFoo}.
  *
  * <p>Implementation is not thread-safe.
  *
@@ -30,7 +30,7 @@ import java.io.OutputStream;
  * @since 1.3
  */
 @Beta
-public class MockHttpContent implements HttpContent {
+public class MockHttpContent implements HttpContentFoo {
 
   /** HTTP content length or {@code -1} by default. */
   private long length = -1;

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpRequestTest.java
@@ -3,7 +3,7 @@ package com.google.api.client.http.javanet;
 import static org.junit.Assert.*;
 
 import com.google.api.client.http.ByteArrayContent;
-import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpContentFoo;
 import com.google.api.client.http.InputStreamContent;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.http.javanet.NetHttpRequest.OutputWriter;
@@ -79,7 +79,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
-    HttpContent content = new InputStreamContent("text/plain", is);
+    HttpContentFoo content = new InputStreamContent("text/plain", is);
     request.setStreamingContent(content);
     request.setWriteTimeout(timeout);
     request.execute(new SleepingOutputWriter(5000L));
@@ -103,7 +103,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
-    HttpContent content = new InputStreamContent("text/plain", is);
+    HttpContentFoo content = new InputStreamContent("text/plain", is);
     request.setStreamingContent(content);
 
     LowLevelHttpResponse response = request.execute();
@@ -127,7 +127,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
-    HttpContent content = new InputStreamContent("text/plain", is);
+    HttpContentFoo content = new InputStreamContent("text/plain", is);
     request.setStreamingContent(content);
 
     try {
@@ -160,7 +160,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
-    HttpContent content = new InputStreamContent("text/plain", is);
+    HttpContentFoo content = new InputStreamContent("text/plain", is);
     request.setStreamingContent(content);
 
     try {
@@ -193,7 +193,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
-    HttpContent content = new InputStreamContent("text/plain", is);
+    HttpContentFoo content = new InputStreamContent("text/plain", is);
     request.setStreamingContent(content);
 
     try {
@@ -210,7 +210,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
-    HttpContent content = new InputStreamContent("text/plain", is);
+    HttpContentFoo content = new InputStreamContent("text/plain", is);
     request.setStreamingContent(content);
     request.setContentEncoding("gzip");
     request.execute();
@@ -224,7 +224,7 @@ public class NetHttpRequestTest {
     MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL));
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
-    HttpContent content =
+    HttpContentFoo content =
         new ByteArrayContent("text/plain", "sample".getBytes(StandardCharsets.UTF_8));
     request.setStreamingContent(content);
     request.setContentLength(content.getLength());


### PR DESCRIPTION
This pull request is an example for Linkage Monitor that detects the renamed classes are still referenced by other libraries in the libraries BOM.

```
SEVERE: Newly introduced problems:
Class com.google.api.client.http.HttpContent is not found
  referenced from com.google.api.client.googleapis.media.MediaHttpUploader (com.google.api-client:google-api-client:1.30.11)
  referenced from com.google.api.client.googleapis.services.AbstractGoogleClientRequest (com.google.api-client:google-api-client:1.30.11)
  referenced from com.google.api.client.googleapis.batch.BatchUnparsedResponse (com.google.api-client:google-api-client:1.30.11)
  referenced from com.google.api.client.googleapis.batch.HttpRequestContent (com.google.api-client:google-api-client:1.30.11)
```